### PR TITLE
Add logo for 3.2.0rc0

### DIFF
--- a/v3.2.0rc0/instructions.txt
+++ b/v3.2.0rc0/instructions.txt
@@ -1,0 +1,2 @@
+The GIF of the logo was produced using the file: https://github.com/SciTools/marketing/blob/28ab7a79401a738e58f03939ed1fed2dc008c474/iris/logo/generate_logo.py using the following command:
+`python generate_logo.py --banner_text v3.2.0rc0 --rotate True`


### PR DESCRIPTION
I have added the logo used in the tweet for Iris 3.2.0rc0 as well as some instructions specifying how the logo was created (to specify which command line args I used)